### PR TITLE
Change plugin name + Add Constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # CC Compat with WooCommerce
-Plugin to facilitate Classic Commerce compatibility with WooCommerce Addons
+Plugin to facilitate Classic Commerce compatibility for WooCommerce Addons

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # CC Compat with WooCommerce
-Plugin to facilitate Classic Commerce compatibility with WooCommerce 
+Plugin to facilitate Classic Commerce compatibility with WooCommerce Addons

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -1,10 +1,29 @@
 <?php
 /*
-Plugin Name: WooCommerce Placeholder
-Description: Makes WooCommerce extensions think WooCommerce is present and active.
+Plugin Name: CC Compatibility for Woo Addons
+Description: A compatibility plugin for some WooCommerce addons to work with ClassicCommerce.
 Author: ZigPress
 Version: 9999.0
 Requires at least: 4.9
 Tested up to: 5.3
 Author URI: https://www.zigpress.com/
 */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'CCWOOADDONSCOMPAT_VERSION', '10.0.1111' ); // DO NOT change the version in the plugin header or the Earth will fall on you :P 
+
+define( 'CCWOOADDONSCOMPAT__FILE__', __FILE__ );
+define( 'CCWOOADDONSCOMPAT_PATH', plugin_dir_path( WOOADDONSCOMPAT__FILE__ ) );
+
+if( !defined( 'CCWOOADDONSCOMPAT_PLUGIN_BASE' ) ) {
+	define( 'CCWOOADDONSCOMPAT_PLUGIN_BASE', plugin_basename( WOOADDONSCOMPAT__FILE__ ) );
+}
+
+function ccwooaddonscompat_hide_view_details( $plugin_meta, $plugin_file, $plugin_data, $status ) {
+	if( WOOADDONSCOMPAT_PLUGIN_BASE == $plugin_file ) {
+		unset( $plugin_meta[2] );		
+	}
+	return $plugin_meta;
+}
+add_filter( 'plugin_row_meta', 'ccwooaddonscompat_hide_view_details', 10, 4 );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -14,14 +14,14 @@ defined( 'ABSPATH' ) || exit;
 define( 'CCWOOADDONSCOMPAT_VERSION', '9999.0' ); // DO NOT change the version in the plugin header or the Earth will fall on you :P 
 
 define( 'CCWOOADDONSCOMPAT__FILE__', __FILE__ );
-define( 'CCWOOADDONSCOMPAT_PATH', plugin_dir_path( WOOADDONSCOMPAT__FILE__ ) );
+define( 'CCWOOADDONSCOMPAT_PATH', plugin_dir_path( CCWOOADDONSCOMPAT__FILE__ ) );
 
 if( !defined( 'CCWOOADDONSCOMPAT_PLUGIN_BASE' ) ) {
-	define( 'CCWOOADDONSCOMPAT_PLUGIN_BASE', plugin_basename( WOOADDONSCOMPAT__FILE__ ) );
+	define( 'CCWOOADDONSCOMPAT_PLUGIN_BASE', plugin_basename( CCWOOADDONSCOMPAT__FILE__ ) );
 }
 
 function ccwooaddonscompat_hide_view_details( $plugin_meta, $plugin_file, $plugin_data, $status ) {
-	if( WOOADDONSCOMPAT_PLUGIN_BASE == $plugin_file ) {
+	if( CCWOOADDONSCOMPAT_PLUGIN_BASE == $plugin_file ) {
 		unset( $plugin_meta[2] );		
 	}
 	return $plugin_meta;

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -4,14 +4,14 @@ Plugin Name: CC Compatibility for Woo Addons
 Description: A compatibility plugin for some WooCommerce addons to work with ClassicCommerce.
 Author: ZigPress
 Version: 9999.0
-Requires at least: 4.9
-Tested up to: 5.3
+Requires at least: 1.0.0
+Tested up to: 1.1.2
 Author URI: https://www.zigpress.com/
 */
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CCWOOADDONSCOMPAT_VERSION', '10.0.1111' ); // DO NOT change the version in the plugin header or the Earth will fall on you :P 
+define( 'CCWOOADDONSCOMPAT_VERSION', '9999.0' ); // DO NOT change the version in the plugin header or the Earth will fall on you :P 
 
 define( 'CCWOOADDONSCOMPAT__FILE__', __FILE__ );
 define( 'CCWOOADDONSCOMPAT_PATH', plugin_dir_path( WOOADDONSCOMPAT__FILE__ ) );


### PR DESCRIPTION
This PR renames the plugin as discussed [here](https://github.com/Classic-Commerce/cc-compat-woo/issues/1).

Defines the plugin's constants and applies a filter function to remove the View Details link on the plugins page.